### PR TITLE
Static library name on Windows.

### DIFF
--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -50,7 +50,7 @@ elseif(UNIX)
     set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/libclarabel_c.a")
 elseif(WIN32)
     set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/clarabel_c.dll.lib")
-    set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/libclarabel_c.lib")
+    set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/clarabel_c.lib")
 endif()
 
 # Wrap the Rust library in a CMake library target


### PR DESCRIPTION
Thanks for the great solver! It appears that the static library name on Windows should be `clarabel_c.lib` instead of `libclarabel_c.lib`.