### PR TITLE
Allow for enabling SDP without choosing a specific BLAS

### DIFF
--- a/rust_wrapper/Cargo.toml
+++ b/rust_wrapper/Cargo.toml
@@ -16,9 +16,9 @@ codegen-units = 1
 
 [features]
 # Define features for SDP support in Clarabel.rs
-sdp = []
-sdp-accelerate = ["sdp", "clarabel/sdp", "clarabel/sdp-accelerate"]
-sdp-netlib     = ["sdp", "clarabel/sdp", "clarabel/sdp-netlib"]
-sdp-openblas   = ["sdp", "clarabel/sdp", "clarabel/sdp-openblas"]
-sdp-mkl        = ["sdp", "clarabel/sdp", "clarabel/sdp-mkl"]
-sdp-r          = ["sdp", "clarabel/sdp", "clarabel/sdp-r"]
+sdp = ["clarabel/sdp"]
+sdp-accelerate = ["sdp", "clarabel/sdp-accelerate"]
+sdp-netlib     = ["sdp", "clarabel/sdp-netlib"]
+sdp-openblas   = ["sdp", "clarabel/sdp-openblas"]
+sdp-mkl        = ["sdp", "clarabel/sdp-mkl"]
+sdp-r          = ["sdp", "clarabel/sdp-r"]


### PR DESCRIPTION
This helped while I was investigating https://github.com/oxfordcontrol/Clarabel.rs/issues/61.

If `Clarabel.cpp` has `sdp` enabled but `Clarabel.rs` does not, it results in a build error.  Enabling SDP on `Clarabel.cpp` should always enable the same in `Clarabel.rs`.