### PR TITLE
Remove explicit template instantiations

### DIFF
--- a/include/cpp/DefaultInfo.h
+++ b/include/cpp/DefaultInfo.h
@@ -30,8 +30,4 @@ struct DefaultInfo
     clarabel::SolverStatus status;
 };
 
-// Instantiate the templates
-template struct DefaultInfo<double>;
-template struct DefaultInfo<float>;
-
 } // namespace clarabel

--- a/include/cpp/DefaultSettings.h
+++ b/include/cpp/DefaultSettings.h
@@ -59,10 +59,6 @@ struct DefaultSettings
     static DefaultSettings<T> default_settings();
 };
 
-// Instantiate the templates
-template struct DefaultSettings<double>;
-template struct DefaultSettings<float>;
-
 template<typename T = double>
 class DefaultSettingsBuilder
 {

--- a/include/cpp/DefaultSolution.h
+++ b/include/cpp/DefaultSolution.h
@@ -67,8 +67,4 @@ class DefaultSolution
     }
 };
 
-// Instantiate the templates
-template struct DefaultSolution<double>;
-template struct DefaultSolution<float>;
-
 } // namespace clarabel


### PR DESCRIPTION
I know of no reason why explicit template instantiations should ever appear in a header file: code that includes the header file will already implicitly instantiate any templates that it uses. (See https://en.cppreference.com/w/cpp/language/class_template.) The effect of the instantiations is only to copy unnecessary object code into every translation unit that calls this library.

In any case, for trivial wrapper structs it's always better to use function inlining anyway; for performance, we don't actually want to be jumping through extern functions when dealing with these wrappers.