### PR TITLE
Adding missing tests for the C++ wrapper

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,9 +20,16 @@ add_executable(clarabel_cpp_tests
     api_dimension_checks.cpp
     basic_lp.cpp
     basic_qp.cpp
+    basic_eq_constrained.cpp
+    basic_powcone.cpp
+    basic_genpowcone.cpp
+    basic_expcone.cpp
+    basic_sdp.cpp
+    basic_socp.cpp
     basic_unconstrained.cpp
     mixed_conic.cpp
     data_updating.cpp
+    sdp_chordal.cpp
 )
 target_link_libraries(clarabel_cpp_tests 
     libclarabel_c_shared

--- a/tests/basic_eq_constrained.cpp
+++ b/tests/basic_eq_constrained.cpp
@@ -1,0 +1,108 @@
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+SparseMatrix<double> eq_constrained_A1() {
+    // A =
+    //[ 0. 1.  1.;
+    //  0. 1. -1.]
+    int colptr[] = { 0, 0, 2, 4 }; // start index per column + 1 for last col
+    int rowval[] = { 0, 1, 0, 1 }; // nonzero row indices
+    double nzval[] = { 1., 1., 1., -1. };
+    return SparseMatrix<double>::Map(
+        2 /*rows*/, 3 /*cols*/, 4 /*nonzeros*/, colptr, rowval, nzval);
+}
+
+SparseMatrix<double> eq_constrained_A2() {
+    // A = [
+    // 0    1.0   1.0;
+    // 0    1.0  -1.0;
+    //1.0   2.0  -1.0l
+    //2.0  -1.0   3.0l
+    //]
+    int colptr[] = { 0, 2, 6, 10 }; // start index per column + 1 for last col
+    int rowval[] = { 2, 3, 0, 1, 2, 3, 0, 1, 2, 3}; // nonzero row indices
+    double nzval[] = {1., 2., 1., 1., 2., -1., 1., -1., -1., 3. };
+    return SparseMatrix<double>::Map(
+        4 /*rows*/, 3 /*cols*/, 10 /*nonzeros*/, colptr, rowval, nzval);
+}
+
+TEST(BasicEqConstrainedTest, Feasible)
+{
+    SparseMatrix<double> P = MatrixXd::Identity(3, 3).sparseView();
+    P.makeCompressed();
+
+    Vector<double, 3> c = { 0., 0., 0. };
+
+    SparseMatrix<double> A = eq_constrained_A1();
+
+    Vector<double, 2> b = {2., 0.};
+
+    vector<SupportedConeT<double>> cones = {ZeroConeT<double>(2)};
+
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Compare the solution to the reference solution
+    Vector3d ref_solution{ 0., 1., 1. };
+    ASSERT_EQ(solution.x.size(), 3);
+    ASSERT_TRUE(solution.x.isApprox(ref_solution, 1e-6));
+}
+
+TEST(BasicEqConstrainedTest, PrimalInfeasible)
+{
+    SparseMatrix<double> P = MatrixXd::Identity(3, 3).sparseView();
+    P.makeCompressed();
+
+    Vector<double, 3> c = { 0., 0., 0. };
+
+    SparseMatrix<double> A = eq_constrained_A2();
+
+    Vector<double, 4> b = {1., 1., 1., 1.};
+
+    vector<SupportedConeT<double>> cones = {ZeroConeT<double>(4)};
+
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::PrimalInfeasible);
+}
+
+TEST(BasicEqConstrainedTest, DualInfeasible)
+{
+    SparseMatrix<double> P = MatrixXd::Identity(3, 3).sparseView();
+    P.makeCompressed();
+    P.coeffRef(0,0) = 0.0;
+
+    Vector<double, 3> c = { 1., 1., 1. };
+
+    SparseMatrix<double> A = eq_constrained_A1();
+
+    Vector<double, 2> b = {2., 0.};
+
+    vector<SupportedConeT<double>> cones = {ZeroConeT<double>(2)};
+
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::DualInfeasible);
+}

--- a/tests/basic_expcone.cpp
+++ b/tests/basic_expcone.cpp
@@ -1,0 +1,107 @@
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+class BasicExpConeTest : public testing::Test
+{
+    // produces data for the following exponential cone problem
+    // max  x
+    // s.t. y * exp(x / y) <= z
+    //      y == 1, z == exp(5)
+  protected:
+    SparseMatrix<double> P, A;
+    Vector<double, 3> c = {-1., 0., 0.};
+    Vector<double, 5> b = {0., 0., 0., 1.0, exp(5.)};
+    vector<SupportedConeT<double>> cones = {
+        ExponentialConeT<double>(),
+        ZeroConeT<double>(2),
+    };
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    BasicExpConeTest()
+    {
+        P = MatrixXd::Zero(3, 3).sparseView();
+        P.makeCompressed();
+
+        MatrixXd A1 = -MatrixXd::Identity(3,3);
+        MatrixXd A2(2,3);
+        A2 << 0, 1, 0, // y = 1
+              0, 0, 1; // z = exp(5)
+
+        MatrixXd A_dense = MatrixXd::Zero(5,3);
+        A_dense << A1, A2;
+        A = A_dense.sparseView();
+        A.makeCompressed();
+    }
+};
+
+TEST_F(BasicExpConeTest, Feasible)
+{
+    // solve the following exponential cone problem
+    // max  x
+    // s.t. y * exp(x / y) <= z
+    //      y == 1, z == exp(5)
+    //
+    // This is just the default problem data above
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Check the solution
+    Vector3d ref_solution{ 5.0, 1.0, exp(5.0) };
+    ASSERT_EQ(solution.x.size(), 3);
+    ASSERT_TRUE(solution.x.isApprox(ref_solution, 1e-6));
+
+    double ref_obj = -5.0;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-6);
+    ASSERT_NEAR(solution.obj_val_dual, ref_obj, 1e-6);
+}
+
+TEST_F(BasicExpConeTest, PrimalInfeasible)
+{
+    // solve the following exponential cone problem
+    // max  x
+    // s.t. y * exp(x / y) <= z
+    //      y == 1, z == -1
+    //
+    // Same as default, but last element of b is different
+    b[4] = -1.;
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::PrimalInfeasible);
+}
+
+
+TEST_F(BasicExpConeTest, DualInfeasible)
+{
+    // solve the following exponential cone problem
+    // max  x
+    // s.t. y * exp(x / y) <= z
+    //
+    // Same as default, but no equality constraint
+
+    Vector<double, 3> b = {0., 0., 0.};
+    vector<SupportedConeT<double>> cones = {ExponentialConeT<double>()};
+    MatrixXd A1 = -MatrixXd::Identity(3,3);
+    SparseMatrix<double> A = A1.sparseView();
+    A.makeCompressed();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::DualInfeasible);
+}

--- a/tests/basic_genpowcone.cpp
+++ b/tests/basic_genpowcone.cpp
@@ -1,0 +1,65 @@
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+
+TEST(BasicGenPowerConeTest, Feasible)
+{
+    // solve the following power cone problem
+    // max  x1^0.6 y^0.4 + x2^0.1
+    // s.t. x1, y, x2 >= 0
+    //      x1 + 2y  + 3x2 == 3
+    // which is equivalent to
+    // max z1 + z2
+    // s.t. (x1, y, z1) in K_pow(0.6)
+    //      (x2, 1, z2) in K_pow(0.1)
+    //      x1 + 2y + 3x2 == 3
+
+    // x = (x1, y, z1, x2, y2, z2)
+
+    SparseMatrix<double> P = MatrixXd::Zero(6, 6).sparseView();
+    P.makeCompressed();
+    
+    Vector<double, 6> c = { 0., 0., -1., 0., 0., -1. };
+
+    // Assembling A
+    MatrixXd A1_dense = -MatrixXd::Identity(6, 6);
+    MatrixXd A2_dense(2,6);
+    A2_dense << 1., 2., 0., 3., 0., 0., //
+                0., 0., 0., 0., 1., 0.; //
+
+    MatrixXd A_dense = MatrixXd::Zero(8,6);
+    A_dense << A1_dense, A2_dense;
+    SparseMatrix<double> A = A_dense.sparseView();
+    A.makeCompressed();
+
+    // Assembling b
+    Vector<double, 8> b = {0., 0., 0., 0., 0., 0., 3., 1.};
+    // Assembling cones
+
+    Vector<double, 2> cone1 = {0.6, 0.4};
+    Vector<double, 2> cone2 = {0.1, 0.9};
+    vector<SupportedConeT<double>> cones = {GenPowerConeT<double>(cone1, 1), 
+                                            GenPowerConeT<double>(cone2, 1), 
+                                            ZeroConeT<double>(2)};
+
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Compare the solution to the reference solution
+    double ref_obj = -1.8458;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-3);
+}

--- a/tests/basic_genpowcone.cpp
+++ b/tests/basic_genpowcone.cpp
@@ -10,7 +10,6 @@ using namespace std;
 using namespace clarabel;
 using namespace Eigen;
 
-
 TEST(BasicGenPowerConeTest, Feasible)
 {
     // solve the following power cone problem

--- a/tests/basic_powcone.cpp
+++ b/tests/basic_powcone.cpp
@@ -1,0 +1,61 @@
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+TEST(BasicPowerConeTest, Feasible)
+{
+    // solve the following power cone problem
+    // max  x1^0.6 y^0.4 + x2^0.1
+    // s.t. x1, y, x2 >= 0
+    //      x1 + 2y  + 3x2 == 3
+    // which is equivalent to
+    // max z1 + z2
+    // s.t. (x1, y, z1) in K_pow(0.6)
+    //      (x2, 1, z2) in K_pow(0.1)
+    //      x1 + 2y + 3x2 == 3
+
+    // x = (x1, y, z1, x2, y2, z2)
+
+    SparseMatrix<double> P = MatrixXd::Zero(6, 6).sparseView();
+    P.makeCompressed();
+
+    Vector<double, 6> c = { 0., 0., -1., 0., 0., -1. };
+
+    // Assembling A
+    MatrixXd A1_dense = -MatrixXd::Identity(6, 6);
+    MatrixXd A2_dense(2,6);
+    A2_dense << 1., 2., 0., 3., 0., 0., //
+                0., 0., 0., 0., 1., 0.; //
+
+    MatrixXd A_dense = MatrixXd::Zero(8,6);
+    A_dense << A1_dense, A2_dense;
+    SparseMatrix<double> A = A_dense.sparseView();
+    A.makeCompressed();
+
+    // Assembling b
+    Vector<double, 8> b = {0., 0., 0., 0., 0., 0., 3., 1.};
+    // Assembling cones
+    vector<SupportedConeT<double>> cones = {PowerConeT<double>(0.6), 
+                                             PowerConeT<double>(0.1), 
+                                             ZeroConeT<double>(2)};
+
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Compare the solution to the reference solution
+    double ref_obj = -1.8458;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-3);
+}

--- a/tests/basic_sdp.cpp
+++ b/tests/basic_sdp.cpp
@@ -1,0 +1,111 @@
+#ifdef FEATURE_SDP
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+class BasicSDPTest : public testing::Test
+{
+  protected:
+    SparseMatrix<double> P, A;
+    Vector<double, 6> c = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    Vector<double, 6> b = {-3., 1., 4., 1., 2., 5. };
+    vector<SupportedConeT<double>> cones = {
+        PSDTriangleConeT<double>(3),
+    };
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    BasicSDPTest()
+    {
+        MatrixXd P_dense = MatrixXd::Identity(6,6);
+        P = P_dense.sparseView();
+        P.makeCompressed();
+
+        MatrixXd A_dense = MatrixXd::Identity(6,6);
+        A = A_dense.sparseView(); 
+        A.makeCompressed();
+    }
+};
+
+
+TEST_F(BasicSDPTest, Feasible)
+{
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Check the solution
+    Vector<double, 6>  ref_solution = {-3.0729833267361095,
+                                        0.3696004167288786,
+                                        -0.022226685581313674,
+                                        0.31441213129613066,
+                                        -0.026739700851545107,
+                                        -0.016084530571308823};
+    ASSERT_EQ(solution.x.size(), 6);
+    ASSERT_TRUE(solution.x.isApprox(ref_solution, 1e-4));
+
+    double ref_obj = 4.840076866013861;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-6);
+}
+
+TEST_F(BasicSDPTest, EmptyCone)
+{
+    vector<SupportedConeT<double>> empty_cone = {
+        PSDTriangleConeT<double>(0),
+    };
+
+    cones.insert(cones.end(), empty_cone.begin(), empty_cone.end());
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Check the solution
+    Vector<double, 6>  ref_solution = {-3.0729833267361095,
+                                        0.3696004167288786,
+                                        -0.022226685581313674,
+                                        0.31441213129613066,
+                                        -0.026739700851545107,
+                                        -0.016084530571308823,};
+    ASSERT_EQ(solution.x.size(), 6);
+    ASSERT_TRUE(solution.x.isApprox(ref_solution, 1e-4));
+
+    double ref_obj = 4.840076866013861;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-6);
+}
+
+TEST_F(BasicSDPTest, PrimalInfeasible)
+{
+    MatrixXd I1 = MatrixXd::Identity(6, 6);
+    MatrixXd I2 = -MatrixXd::Identity(6, 6);
+    MatrixXd A_dense = MatrixXd::Zero(12, 6);
+    A_dense << I1,
+             I2;
+    A = A_dense.sparseView();
+    A.makeCompressed();
+
+    vector<SupportedConeT<double>> extra_cone = {
+        PSDTriangleConeT<double>(3),
+    };
+    cones.insert(cones.end(), extra_cone.begin(), extra_cone.end());
+
+    Vector<double, 12> b = {-3., 1., 4., 1., 2., 5. , 0., 0., 0., 0., 0., 0.};
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::PrimalInfeasible);
+}
+#endif

--- a/tests/basic_socp.cpp
+++ b/tests/basic_socp.cpp
@@ -1,0 +1,86 @@
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+class BasicSOCPTest : public testing::Test
+{
+  protected:
+    SparseMatrix<double> P, A;
+    Vector<double, 3> c = {0.1, -2.0, 1.0};
+    Vector<double, 9> b = {1., 1., 1., 1., 1., 1., 0., 0., 0. };
+    vector<SupportedConeT<double>> cones = {
+        NonnegativeConeT<double>(3),
+        NonnegativeConeT<double>(3),
+        SecondOrderConeT<double>(3),
+    };
+    DefaultSettings<double> settings = DefaultSettings<double>::default_settings();
+
+    BasicSOCPTest()
+    {
+        int colptr[] = { 0, 3, 6, 9 }; // start index per column + 1 for last col
+        int rowval[] = { 0, 1, 2, 0, 1, 2, 0, 1, 2 }; // nonzero row indices
+        double nzval[] = {1.4652521089139698,
+                0.6137176286085666,
+                -1.1527861771130112,
+                0.6137176286085666,
+                2.219109946678485,
+                -1.4400420548730628,
+                -1.1527861771130112,
+                -1.4400420548730628,
+                1.6014483534926371};
+        P = SparseMatrix<double>::Map(
+                3 /*rows*/, 3 /*cols*/, 9 /*nonzeros*/, colptr,rowval, nzval
+            );
+        MatrixXd I1 =  MatrixXd::Identity(3, 3);
+        MatrixXd I2 = -MatrixXd::Identity(3, 3);
+        MatrixXd I3 = 0.5*MatrixXd::Identity(3, 3);
+        MatrixXd A_dense = MatrixXd::Zero(9, 3);
+        A_dense << I1,
+                   I2,
+                   I3;
+        A_dense *= 2.0;
+        A = A_dense.sparseView();
+        A.makeCompressed();
+    }
+};
+
+
+TEST_F(BasicSOCPTest, Feasible)
+{
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::Solved);
+
+    // Check the solution
+    Vector3d ref_solution{ -0.5, 0.435603, -0.245459 };
+    ASSERT_EQ(solution.x.size(), 3);
+    ASSERT_TRUE(solution.x.isApprox(ref_solution, 1e-4));
+
+    double ref_obj = -8.4590e-01;
+    ASSERT_NEAR(solution.obj_val, ref_obj, 1e-4);
+    ASSERT_NEAR(solution.obj_val_dual, ref_obj, 1e-4);
+}
+
+TEST_F(BasicSOCPTest, PrimalFeasible)
+{
+    b[6] = -10.;
+
+    DefaultSolver<double> solver(P, c, A, b, cones, settings);
+    solver.solve();
+
+    DefaultSolution<double> solution = solver.solution();
+    ASSERT_EQ(solution.status, SolverStatus::PrimalInfeasible);
+
+    EXPECT_TRUE(isnan(solution.obj_val));
+    EXPECT_TRUE(isnan(solution.obj_val_dual));
+}

--- a/tests/sdp_chordal.cpp
+++ b/tests/sdp_chordal.cpp
@@ -106,7 +106,6 @@ TEST_F(SDPChordalTest, Feasible)
                                                                  ClarabelCliqueMergeMethods::PARENT_CHILD,
                                                                  ClarabelCliqueMergeMethods::NONE};
 
-
     for (auto &compact : compacts){
         for (auto &complete_dual : complete_duals){
             for (auto &merge_method : merge_methods){

--- a/tests/sdp_chordal.cpp
+++ b/tests/sdp_chordal.cpp
@@ -1,0 +1,125 @@
+#ifdef FEATURE_SDP
+#include <Clarabel>
+#include <Eigen/Eigen>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+using namespace std;
+using namespace clarabel;
+using namespace Eigen;
+
+SparseMatrix<double> create_A() {
+    // A =
+    //[ 0. 1.  1.;
+    //  0. 1. -1.]
+    int colptr[] = { 0, 1, 4, 5, 8, 9, 10, 13, 16 }; // start index per column + 1 for last col
+    int rowval[] = { 24, 7, 10, 22, 8, 12, 15, 25, 9, 13, 18, 21, 26, 0, 23, 27 }; // nonzero row indices
+    double nzval[] = {             -1.0,
+            -M_SQRT2,
+            -1.0,
+            -1.0,
+            -M_SQRT2,
+            -M_SQRT2,
+            -1.0,
+            -1.0,
+            -M_SQRT2,
+            -M_SQRT2,
+            -M_SQRT2,
+            -1.0,
+            -1.0,
+            -1.0,
+            -1.0,
+            -1.0};
+    return SparseMatrix<double>::Map(
+        28 /*rows*/, 8 /*cols*/, 16 /*nonzeros*/, colptr, rowval, nzval);
+}
+
+class SDPChordalTest : public ::testing::Test
+{
+  protected:
+    SparseMatrix<double> P, A;
+    
+    Vector<double, 28> b = {0.0,
+                            3.0,
+                            2. * M_SQRT2,
+                            2.0,
+                            M_SQRT2,
+                            M_SQRT2,
+                            3.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,};
+    Vector<double, 8> c = {-1.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0, -0.0};
+    vector<SupportedConeT<double>> cones = {
+        NonnegativeConeT<double>(1),
+        PSDTriangleConeT<double>(6),
+        PowerConeT<double>(0.3333333333333333),
+        PowerConeT<double>(0.5),
+    };
+
+    SDPChordalTest()
+    {
+        MatrixXd P_dense = MatrixXd::Zero(8,8);
+        P = P_dense.sparseView();
+        P.makeCompressed();
+
+        A = create_A();
+
+    }
+};
+
+TEST_F(SDPChordalTest, Feasible)
+{
+    DefaultSettings<double> settings = DefaultSettingsBuilder<double>::default_settings()
+        .verbose(true)
+        .chordal_decomposition_enable(true)
+        .chordal_decomposition_compact(true)
+        .chordal_decomposition_complete_dual(true)
+        .chordal_decomposition_merge_method(ClarabelCliqueMergeMethods::CLIQUE_GRAPH)
+        .max_iter(50)
+        .build();
+
+    Vector<bool, 2> compacts = {false, true};
+    Vector<bool, 2> complete_duals = {false, true};
+    Vector<ClarabelCliqueMergeMethods, 3> merge_methods = {ClarabelCliqueMergeMethods::CLIQUE_GRAPH,
+                                                                 ClarabelCliqueMergeMethods::PARENT_CHILD,
+                                                                 ClarabelCliqueMergeMethods::NONE};
+
+
+    for (auto &compact : compacts){
+        for (auto &complete_dual : complete_duals){
+            for (auto &merge_method : merge_methods){
+                settings.chordal_decomposition_compact = compact;
+                settings.chordal_decomposition_complete_dual = complete_dual;
+                settings.chordal_decomposition_merge_method = merge_method;
+                DefaultSolver<double> solver(P, c, A, b, cones, settings);
+                solver.solve();
+
+                DefaultSolution<double> solution = solver.solution();
+                ASSERT_EQ(solution.status, SolverStatus::Solved);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
As mentioned in #38 then some tests were missing. The missing tests were for

* Equality constrained optimization
* Power Cones
* Generalized Power Cones
* Exponential Cones
* Second Order Cones
* Chordal Decomposition

The added tests are adapted from the Rust tests. 