### PR TITLE
Fix issues #44, #45, and #46

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 
+# Set the root directory of the project. This is needed
+# so that Clarabel.cpp can be consumed by other projects via
+# `add_subdirectory`
+set(CLARABEL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 #----------------------------------------------
 # Clarabel feature configuration
 #----------------------------------------------
 set(CLARABEL_FEATURE_SDP "none" CACHE STRING "Package for SDP to be selected")
-set_property(CACHE CLARABEL_FEATURE_SDP PROPERTY STRINGS 
+set_property(CACHE CLARABEL_FEATURE_SDP PROPERTY STRINGS
     none
     sdp-accelerate
     sdp-netlib

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Define a list of target names
-set(CPP_EXAMPLES 
+set(CPP_EXAMPLES
   example_expcone
   example_lp
   example_powcone
@@ -14,7 +14,7 @@ set(CPP_EXAMPLES
 # Define an executable target for each example
 foreach(EXAMPLE_NAME ${CPP_EXAMPLES})
   add_executable("cpp_${EXAMPLE_NAME}" ${EXAMPLE_NAME}.cpp)
-  target_compile_features("cpp_${EXAMPLE_NAME}" PRIVATE cxx_std_11) # Use C++11
+  target_compile_features("cpp_${EXAMPLE_NAME}" PRIVATE cxx_std_14) # Eigen requires at least c++14 support
 
   # Link to clarabel built from the Rust wrapper
   target_link_libraries("cpp_${EXAMPLE_NAME}" PRIVATE libclarabel_c_shared)

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -20,10 +20,10 @@ set(CLARABEL_C_OUTPUT_DIR ${clarabel_c_output_directory} PARENT_SCOPE)
 
 
 # -------------------------------------
-# Cargo features configuration 
+# Cargo features configuration
 #--------------------------------------
 
-# A list of features to pass to rustc 
+# A list of features to pass to rustc
 set(CLARABEL_BUILD_FEATURES "")
 
 # SDP feature flag
@@ -31,7 +31,7 @@ if(NOT CLARABEL_FEATURE_SDP STREQUAL "none")
 
     # Set the Rust feature flag
     set(CLARABEL_BUILD_FEATURES "${CLARABEL_BUILD_FEATURES},${CLARABEL_FEATURE_SDP}")
-    
+
     # Define the FEATURE_SDP flag for all targets that link against clarabel_c
     target_compile_definitions(libclarabel_c_static INTERFACE FEATURE_SDP)
     target_compile_definitions(libclarabel_c_shared INTERFACE FEATURE_SDP)
@@ -42,7 +42,7 @@ if(CLARABEL_FEATURE_FAER_SPARSE)
 
     # Set the Rust feature flag
     set(CLARABEL_BUILD_FEATURES "${CLARABEL_BUILD_FEATURES},faer-sparse")
-    
+
     # Define the FEATURE_FAER_SPARSE flag for all targets that link against clarabel_c
     target_compile_definitions(libclarabel_c_static INTERFACE FEATURE_FAER_SPARSE)
     target_compile_definitions(libclarabel_c_shared INTERFACE FEATURE_FAER_SPARSE)
@@ -53,7 +53,7 @@ if(CLARABEL_FEATURE_SERDE)
 
     # Set the Rust feature flag
     set(CLARABEL_BUILD_FEATURES "${CLARABEL_BUILD_FEATURES},serde")
-    
+
     # Define the FEATURE_SERDE flag for all targets that link against clarabel_c
     target_compile_definitions(libclarabel_c_static INTERFACE FEATURE_SERDE)
     target_compile_definitions(libclarabel_c_shared INTERFACE FEATURE_SERDE)
@@ -70,19 +70,6 @@ message("-- Cargo options: " "${clarabel_c_build_flags}")
 # -------------------------------------
 
 
-# Add the cargo project as a custom target
-add_custom_target(
-    libclarabel_c
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/rust_wrapper
-    # Commands for building the Rust library
-    COMMAND cargo build ${clarabel_c_build_flags}
-    COMMAND cargo install cbindgen --version 0.24.5
-    # Generate the C header
-    COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.h --lang c
-    # Generate the C++ header
-    COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.hpp
-)
-
 # Get the path to the Rust library for linking
 if(APPLE)
     set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/libclarabel_c.dylib")
@@ -94,6 +81,24 @@ elseif(WIN32)
     set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/clarabel_c.dll.lib")
     set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/clarabel_c.lib")
 endif()
+
+
+# Add the cargo project as a custom target
+add_custom_target(
+    libclarabel_c
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/rust_wrapper
+    # Commands for building the Rust library
+    COMMAND cargo build ${clarabel_c_build_flags}
+    COMMAND cargo install cbindgen --version 0.24.5
+    # Generate the C header
+    COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.h --lang c
+    # Generate the C++ header
+    COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.hpp
+    BYPRODUCTS
+        "${LIBCLARABEL_C_SHARED_PATH}"
+        "${LIBCLARABEL_C_STATIC_PATH}"
+)
+
 
 # Wrap the Rust library in a CMake library target
 

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -10,10 +10,10 @@ add_library(libclarabel_c_shared INTERFACE)
 # Debug/Release flags
 if(CMAKE_BUILD_TYPE MATCHES Release)
    set(clarabel_c_build_flags "--release")
-   set(clarabel_c_output_directory "${CMAKE_SOURCE_DIR}/rust_wrapper/target/release")
+   set(clarabel_c_output_directory "${CLARABEL_ROOT_DIR}/rust_wrapper/target/release")
 else()
     set(clarabel_c_build_flags "")
-    set(clarabel_c_output_directory "${CMAKE_SOURCE_DIR}/rust_wrapper/target/debug")
+    set(clarabel_c_output_directory "${CLARABEL_ROOT_DIR}/rust_wrapper/target/debug")
 endif()
 
 set(CLARABEL_C_OUTPUT_DIR ${clarabel_c_output_directory} PARENT_SCOPE)
@@ -86,7 +86,7 @@ endif()
 # Add the cargo project as a custom target
 add_custom_target(
     libclarabel_c
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/rust_wrapper
+    WORKING_DIRECTORY ${CLARABEL_ROOT_DIR}/rust_wrapper
     # Commands for building the Rust library
     COMMAND cargo build ${clarabel_c_build_flags}
     COMMAND cargo install cbindgen --version 0.24.5
@@ -104,10 +104,10 @@ add_custom_target(
 
 # Static library
 target_link_libraries(libclarabel_c_static INTERFACE ${LIBCLARABEL_C_STATIC_PATH})
-target_include_directories(libclarabel_c_static INTERFACE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(libclarabel_c_static INTERFACE ${CLARABEL_ROOT_DIR}/include)
 add_dependencies(libclarabel_c_static libclarabel_c)
 
 # Shared library
 target_link_libraries(libclarabel_c_shared INTERFACE ${LIBCLARABEL_C_SHARED_PATH})
-target_include_directories(libclarabel_c_shared INTERFACE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(libclarabel_c_shared INTERFACE ${CLARABEL_ROOT_DIR}/include)
 add_dependencies(libclarabel_c_shared libclarabel_c)


### PR DESCRIPTION
This PR fixes issues #44, #45, and #46. Each one is a relatively small fix, so I grouped them together.

Merging this PR ensures that the examples are built with C++14 (which eigen requires); it fixes an issue where ninja builds fail on a fresh download of the repo; and it adds support for using Clarabel.cpp via `add_subdirectory`