### PR TITLE
Remove unncessary <iostream> include

### DIFF
--- a/include/cpp/CscMatrix.h
+++ b/include/cpp/CscMatrix.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 #include <type_traits>
 
 namespace clarabel


### PR DESCRIPTION
Including `<iostream>` means introducing the static (global) constructors and destructors for `std::cin`, `std::cerr`, and `std::cout`. That extra `init` and `fini` code is undesirable when those streams are not actually used.

(See https://en.cppreference.com/w/cpp/io/ios_base/Init for details.)