### PR TITLE
Compiling Clarabel.cpp in larger CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # SDP feature configuration
 set(CLARABEL_FEATURE_SDP "none" CACHE STRING "Package for SDP to be selected")
-set_property(CACHE CLARABEL_FEATURE_SDP PROPERTY STRINGS 
+set_property(CACHE CLARABEL_FEATURE_SDP PROPERTY STRINGS
     none
     sdp-accelerate
     sdp-netlib
@@ -42,7 +42,10 @@ endif()
 add_subdirectory(rust_wrapper)
 
 # Add other subdirectories
-add_subdirectory(examples)
+option(CLARABEL_BUILD_EXAMPLES "Build examples for Clarabel.cpp" true)
+if(CLARABEL_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 # Add tests
 option(CLARABEL_BUILD_TESTS "Build the unit tests for Clarabel.cpp" false)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 
+
+# Include directories
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/c)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # SDP feature configuration
 set(CLARABEL_FEATURE_SDP "none" CACHE STRING "Package for SDP to be selected")
 set_property(CACHE CLARABEL_FEATURE_SDP PROPERTY STRINGS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,13 @@ if(CLARABEL_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
 endif()
+
+
+message(STATUS "Clarabel.cpp: CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
+message(STATUS "Clarabel.cpp: LIBRARY = ${LIBRARY}")
+message(STATUS "Clarabel.cpp: PROJECT_NAME = ${PROJECT_NAME}")
+install(TARGETS libclarabel_c_shared EXPORT ${PROJECT_NAME}
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    )
+
+install(EXPORT ${PROJECT_NAME} DESTINATION cmake)

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 # Add the cargo project as a custom target
 add_custom_target(
     libclarabel_c
-    WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}/rust_wrapper
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     # Commands for building the Rust library
     COMMAND cargo build ${clarabel_c_build_flags}
     COMMAND cargo install cbindgen --version 0.24.5

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -10,19 +10,25 @@ add_library(libclarabel_c_shared INTERFACE)
 # Debug/Release flags
 if(CMAKE_BUILD_TYPE MATCHES Release)
    set(clarabel_c_build_flags "--release")
-   set(clarabel_c_output_directory "${CMAKE_SOURCE_DIR}/rust_wrapper/target/release")
+   set(clarabel_c_output_directory "${CMAKE_PROJECT_DIR}/rust_wrapper/target/release")
 else()
     set(clarabel_c_build_flags "")
-    set(clarabel_c_output_directory "${CMAKE_SOURCE_DIR}/rust_wrapper/target/debug")
+    set(clarabel_c_output_directory "${CMAKE_PROJECT_DIR}/rust_wrapper/target/debug")
 endif()
 
-set(CLARABEL_C_OUTPUT_DIR ${clarabel_c_output_directory} PARENT_SCOPE)
+if (CLARABEL_C_OUTPUT_DIR)
+    message(STATUS "using CLARABEL_C_OUTPUT_DIR ${CLARABEL_C_OUTPUT_DIR}")
+else()
+    set(CLARABEL_C_OUTPUT_DIR ${clarabel_c_output_directory} PARENT_SCOPE)
+    set(CLARABEL_C_OUTPUT_DIR ${clarabel_c_output_directory})
+    message(STATUS "setting CLARABEL_C_OUTPUT_DIR to ${clarabel_c_output_directory}")
+endif()
+
 
 # SDP feature flag
 if(NOT CLARABEL_FEATURE_SDP STREQUAL "none")
     # Set the Rust feature flag
     set(clarabel_c_build_flags "${clarabel_c_build_flags};--features;${CLARABEL_FEATURE_SDP}")
-    
     # Define the FEATURE_SDP flag for all targets that link against clarabel_c
     target_compile_definitions(libclarabel_c_static INTERFACE FEATURE_SDP)
     target_compile_definitions(libclarabel_c_shared INTERFACE FEATURE_SDP)
@@ -31,7 +37,7 @@ endif()
 # Add the cargo project as a custom target
 add_custom_target(
     libclarabel_c
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/rust_wrapper
+    WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}/rust_wrapper
     # Commands for building the Rust library
     COMMAND cargo build ${clarabel_c_build_flags}
     COMMAND cargo install cbindgen --version 0.24.5
@@ -43,14 +49,14 @@ add_custom_target(
 
 # Get the path to the Rust library for linking
 if(APPLE)
-    set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/libclarabel_c.dylib")
-    set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/libclarabel_c.a")
+    set(LIBCLARABEL_C_SHARED_PATH "${CLARABEL_C_OUTPUT_DIR}/libclarabel_c.dylib")
+    set(LIBCLARABEL_C_STATIC_PATH "${CLARABEL_C_OUTPUT_DIR}/libclarabel_c.a")
 elseif(UNIX)
-    set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/libclarabel_c.so")
-    set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/libclarabel_c.a")
+    set(LIBCLARABEL_C_SHARED_PATH "${CLARABEL_C_OUTPUT_DIR}/libclarabel_c.so")
+    set(LIBCLARABEL_C_STATIC_PATH "${CLARABEL_C_OUTPUT_DIR}/libclarabel_c.a")
 elseif(WIN32)
-    set(LIBCLARABEL_C_SHARED_PATH "${clarabel_c_output_directory}/clarabel_c.dll.lib")
-    set(LIBCLARABEL_C_STATIC_PATH "${clarabel_c_output_directory}/clarabel_c.lib")
+    set(LIBCLARABEL_C_SHARED_PATH "${CLARABEL_C_OUTPUT_DIR}/clarabel_c.dll.lib")
+    set(LIBCLARABEL_C_STATIC_PATH "${CLARABEL_C_OUTPUT_DIR}/clarabel_c.lib")
 endif()
 
 # Wrap the Rust library in a CMake library target

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -45,6 +45,7 @@ add_custom_target(
     COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.h --lang c
     # Generate the C++ header
     COMMAND cbindgen --config cbindgen.toml --crate clarabel_c --output ./headers/clarabel.hpp
+    COMMAND cp ${PROJECT_SOURCE_DIR}/target/release/lib* ${CLARABEL_C_OUTPUT_DIR}
 )
 
 # Get the path to the Rust library for linking

--- a/rust_wrapper/CMakeLists.txt
+++ b/rust_wrapper/CMakeLists.txt
@@ -71,3 +71,5 @@ add_dependencies(libclarabel_c_static libclarabel_c)
 target_link_libraries(libclarabel_c_shared INTERFACE ${LIBCLARABEL_C_SHARED_PATH})
 target_include_directories(libclarabel_c_shared INTERFACE ${CMAKE_SOURCE_DIR}/include)
 add_dependencies(libclarabel_c_shared libclarabel_c)
+
+install(FILES "${CLARABEL_C_OUTPUT_DIR}/libclarabel_c.so" DESTINATION "lib")


### PR DESCRIPTION
Hi,
we are working on integrating clarabel via Clarabel.cpp into [acados](https://github.com/acados/acados) as an additional QP solver, see https://github.com/acados/acados/pull/1168.
In order to get the compilation working in our project, we made the changes suggested here in this PR.
I would be happy if you could review them.

## Changes summarized:
- add include directories explicitly
- make building examples optional
- allow setting `CLARABEL_C_OUTPUT_DIR` from outside
- copy lib to `CLARABEL_C_OUTPUT_DIR`
- use `PROJECT_SOURCE_DIR` instead of `CMAKE_PROJECT_DIR`
- add install targets